### PR TITLE
Acknowledge support for a list of adresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ are recognized by ```IsImportantPacket```.
 
 #### 10. ```void ActiveACK(const uint8_t len, const uint16_t array[]={})``` <a id="activeack"></a>
 
-Acknowleges the frames coming from one of the adresses listed in the array. Sends an ACK by pulling down the bus line into dominant state for 1 timeslot.
+Acknowleges the frames coming from adresses listed in the array. Sends an ACK by pulling down the bus line into dominant state for 1 timeslot.
+IMPORTANT : you have to indicate the **lenght** of the array of adresses you are passing.
 
 Example:
 
@@ -333,8 +334,8 @@ Example:
 
 void setup() {
   TVanBus::Setup(RX_PIN, TX_PIN);
-  uint16_t KnownIdens[] = {0x8EC};
-  VanBusRx.ActiveACK(1, KnownIdens);
+  uint16_t KnownIdens[] = {0x8EC, 0x8C4};
+  VanBusRx.ActiveACK(2, KnownIdens);
 }
 ```
 
@@ -507,6 +508,8 @@ Only available when ```#define VAN_RX_IFS_DEBUGGING``` is uncommented (see
 
 Currently the library supports only 125 kbit/s VAN bus. Need to add support for different rate, like 62.5 kbit/s,
 which can be passed as an optional parameter to ```VanBusRx.Setup(...)```.
+
+Some equipments on a VAN bus use a special frame called Remote Transmission Request (RTR). A device interrogates another by sending a "blank" frame, without any data payload. The target device completes the message in real time by inserting its data plus a checksum directly into this request frame, creating one complete message on the bus. The library doesn't support answering to RTR frames yet.
 
 ## 📖 License<a name = "license"></a>
 

--- a/README.md
+++ b/README.md
@@ -249,12 +249,13 @@ Interfaces for receiving packets:
 7. [```int GetNQueued()```](#getnqueued)
 8. [```int GetMaxQueued()```](#getmaxqueued)
 9. [```void SetDropPolicy(int startAt, bool (*isEssential)(const TVanPacketRxDesc&) = 0)```](#setdroppolicy)
+10. [```void ActiveACK(const uint8_t len, const uint16_t array[]={})```](#activeack)
 
 Interfaces for transmitting packets:
 
-10. [```bool SyncSendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)```](#syncsendpacket)
-11. [```bool SendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)```](#sendpacket)
-12. [```uint32_t GetTxCount()```](#gettxcount)
+11. [```bool SyncSendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)```](#syncsendpacket)
+12. [```bool SendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)```](#sendpacket)
+13. [```uint32_t GetTxCount()```](#gettxcount)
 
 ---
 
@@ -322,15 +323,38 @@ VanBusRx.SetDropPolicy(VAN_PACKET_QUEUE_SIZE * 8 / 10, &IsImportantPacket);
 The above example will drop incoming packets if the receive queue contains 48 or more packets, unless they
 are recognized by ```IsImportantPacket```.
 
-#### 10. ```bool SyncSendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)``` <a id="syncsendpacket"></a>
+#### 10. ```void ActiveACK(const uint8_t len, const uint16_t array[]={})``` <a id="activeack"></a>
+
+Acknowleges the frames coming from one of the adresses listed in the array. Sends an ACK by pulling down the bus line into dominant state for 1 timeslot.
+
+Example:
+
+```cpp
+
+void setup() {
+  TVanBus::Setup(RX_PIN, TX_PIN);
+  uint16_t KnownIdens[] = {0x8EC};
+  VanBusRx.ActiveACK(1, KnownIdens);
+}
+```
+
+To disable :
+
+```cpp
+void loop() {
+  VanBusRx.ActiveACK(0);
+}
+```
+
+#### 11. ```bool SyncSendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)``` <a id="syncsendpacket"></a>
 
 Sends a packet for transmission. Returns ```true``` if the packet was successfully transmitted.
 
-#### 11. ```bool SendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)``` <a id="sendpacket"></a>
+#### 12. ```bool SendPacket(uint16_t iden, uint8_t cmdFlags, const uint8_t* data, size_t dataLen, unsigned int timeOutMs = 10)``` <a id="sendpacket"></a>
 
 Queues a packet for transmission. Returns ```true``` if the packet was successfully queued.
 
-#### 12. ```uint32_t GetTxCount()``` <a id="gettxcount"></a>
+#### 13. ```uint32_t GetTxCount()``` <a id="gettxcount"></a>
 
 Returns the number of VAN packets, offered for transmitting, since power-on. Counter may roll over.
 

--- a/src/VanBusRx.cpp
+++ b/src/VanBusRx.cpp
@@ -507,6 +507,35 @@ void TVanPacketRxDesc::DumpRaw(Stream& s, char last) const
     s.print(last);
 } // TVanPacketRxDesc::DumpRaw
 
+void TVanPacketRxQueue::ActiveACK(const uint8_t len, const uint16_t array[]={}) //optionnal array for when len==0
+{
+    if (len==0)
+    {
+        ActiveAckStatus = false;
+        idenAckLen = 0;
+        return;
+    }
+    else { //check if the array given by the user has the correct length? :  if(array[len-1] != NULL)
+        ActiveAckStatus = true;
+        idenAckLen = len;
+        for(uint i = 0; i < len; i++){
+            idenAck[i]=array[i];
+        }
+    }
+}
+
+bool TVanPacketRxDesc::decisionActiveACK()
+{
+    if(TVanPacketRxQueue::ActiveAckStatus == false || TVanPacketRxQueue::idenAckLen == 0){return 0;}
+    if((CommandFlags() ^ 0b0100) & 0b0101){return 0;} // (if != 0) do not acknowledge if Request Acknowledge is 0 or if we are receiving an RTR frame.
+    for(int i=0 ; i < TVanPacketRxQueue::idenAckLen ; i++){
+        if(Iden() == TVanPacketRxQueue::idenAck[i]){
+            return 1;
+        }
+    }
+    return 0;
+} // TVanPacketRxDesc::decisionActiveACK
+
 // Normal bit time (8 microseconds), expressed as number of CPU cycles
 #define VAN_NORMAL_BIT_TIME_CPU_CYCLES (CPU_CYCLES(667))
 
@@ -1226,35 +1255,50 @@ void IRAM_ATTR RxPinChangeIsr()
             // Experiment for 3 last "0"-bits: too short means it is not EOD
             && (nBits != 3 || nCycles > CPU_CYCLES(1963)))
         {
+            const unsigned long eodMicrosActiveAck = micros() - 6; //record the time when eod detected, 6us offset on ESP32S3 +-2.5us
+
             rxDesc->state = VAN_RX_WAITING_ACK;
             DEBUG_IFS(toState, VAN_RX_WAITING_ACK);
 
             rxDesc->ack = VAN_NO_ACK;
 
             TRIGGER_ANALYSER_WAIT_ACK_ISR;
-
-            // Set a timeout for the ACK bit
-
-          #ifdef ARDUINO_ARCH_ESP32
-
-           #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-            timerWrite(timer, 0);
-            timerAlarm(timer, 40 * RX_TIMER_TICKS_PER_MICROSECOND, false, 0);  // 5 time slots = 5 * 8 us = 40 microseconds
-           #else // ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-            timerWrite(timer, 0);
-            timerAlarmEnable(timer);
-           #endif // ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-
-          #else // ! ARDUINO_ARCH_ESP32
-
-            timer1_disable();
-            timer1_attachInterrupt(WaitAckIsr);
-
-            // Clock to timer (prescaler) is always 80 MHz, even if F_CPU is 160 MHz
-            timer1_enable(TIMER_DIVIDER, TIM_EDGE, TIM_SINGLE);
-            timer1_write(40 * TIMER_TICKS_PER_MICROSECOND); // 5 time slots = 5 * 8 us = 40 us = 200 ticks (0.2 microsecond/tick)
-
-          #endif // ARDUINO_ARCH_ESP32
+            
+            if (VanBusRx.ActiveAckStatus && rxDesc->decisionActiveACK()){ 
+                rxDesc->ack = VAN_ACTIVE_ACK;
+                unsigned long elapsedMicros = micros() - eodMicrosActiveAck;
+                while(elapsedMicros < 18){
+                    if(elapsedMicros > 7){  //target : 7-18us duration 11us  actual(ESP32-S3): 9.0/7.7/6.5-17.7/16.6us duration 8.7/10us
+                        digitalWrite(globalTxPin,VAN_BIT_DOMINANT);
+                    }
+                    elapsedMicros = micros() - eodMicrosActiveAck;
+                }
+                digitalWrite(globalTxPin,VAN_BIT_RECESSIVE); 
+            }
+            else{
+                // Set a timeout for the ACK bit
+        
+                #ifdef ARDUINO_ARCH_ESP32
+        
+                #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+                    timerWrite(timer, 0);
+                    timerAlarm(timer, 40 * RX_TIMER_TICKS_PER_MICROSECOND, false, 0);  // 5 time slots = 5 * 8 us = 40 microseconds
+                #else // ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+                    timerWrite(timer, 0);
+                    timerAlarmEnable(timer);
+                #endif // ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+        
+                #else // ! ARDUINO_ARCH_ESP32
+        
+                    timer1_disable();
+                    timer1_attachInterrupt(WaitAckIsr);
+        
+                    // Clock to timer (prescaler) is always 80 MHz, even if F_CPU is 160 MHz
+                    timer1_enable(TIMER_DIVIDER, TIM_EDGE, TIM_SINGLE);
+                    timer1_write(40 * TIMER_TICKS_PER_MICROSECOND); // 5 time slots = 5 * 8 us = 40 us = 200 ticks (0.2 microsecond/tick)
+        
+                #endif // ARDUINO_ARCH_ESP32
+            }
 
         }
         else if (rxDesc->size >= VAN_MAX_PACKET_SIZE)
@@ -1269,10 +1313,15 @@ void IRAM_ATTR RxPinChangeIsr()
     RETURN;
 } // RxPinChangeIsr
 
+bool TVanPacketRxQueue::ActiveAckStatus = false;
+uint8_t TVanPacketRxQueue::idenAckLen = 0;
+uint16_t TVanPacketRxQueue::idenAck[] = {};
+
 // Initializes the VAN packet receiver
 bool TVanPacketRxQueue::Setup(uint8_t rxPin, int queueSize)
 {
     if (pin != VAN_NO_PIN_ASSIGNED) return false; // Already setup
+    ActiveAckStatus = false;
 
   #if defined ANALYSE_WAIT_ACK_ISR || defined ANALYSE_RX_PIN_CHANGE_ISR
     pinMode(ANALYSER_PIN, OUTPUT);
@@ -1334,6 +1383,12 @@ void TVanPacketRxQueue::SetTxPinRecessive(uint8_t txPin)
     pinMode(txPin, OUTPUT);
     digitalWrite(txPin, VAN_BIT_RECESSIVE);  // Set bus state to 'recessive' (CANH and CANL: not driven)
 } // TVanPacketRxQueue::SetTxPinRecessive
+
+void TVanPacketRxQueue::SetTxPinDominant(uint8_t txPin)
+{
+    pinMode(txPin, OUTPUT);
+    digitalWrite(txPin, VAN_BIT_DOMINANT);  // Set bus state to 'dominant' (CANH active high and CANL active low)
+} // TVanPacketRxQueue::SetTxPinDominant
 
 // Copy a VAN packet out of the receive queue, if available. Otherwise, returns false.
 // If a valid pointer is passed to 'isQueueOverrun', will report then clear any queue overrun condition.

--- a/src/VanBusRx.h
+++ b/src/VanBusRx.h
@@ -280,7 +280,7 @@ class TVanPacketRxDesc
         size = 0;
         state = VAN_RX_VACANT;
         result = VAN_RX_PACKET_OK;
-        ack = VAN_NO_ACK;        
+        ack = VAN_NO_ACK;
 
       #define NO_UNCERTAIN_BIT (0)
         uncertainBit1 = NO_UNCERTAIN_BIT;
@@ -410,68 +410,68 @@ class TVanPacketRxQueue
 
   private:
 
-  uint8_t pin;
-  bool enabled;
-  int size;
-  TVanPacketRxDesc* pool;
-  TVanPacketRxDesc* volatile _head;
-  TVanPacketRxDesc* tail;
-  TVanPacketRxDesc* end;
-  volatile bool _overrun;
-  uint32_t txTimerTicks;
-  timercallback txTimerIsr;
-  volatile uint32_t lastMediaAccessAt;  // For carrier sense: CPU cycle counter value when last sensed
-  
-  #ifdef VAN_RX_ISR_DEBUGGING
-  #define N_ISR_DEBUG_PACKETS 3
-  TIsrDebugPacket isrDebugPacketPool[N_ISR_DEBUG_PACKETS];
-  TIsrDebugPacket* isrDebugPacket;
-  #endif // VAN_RX_ISR_DEBUGGING
-  
-  // Some statistics. Numbers can roll over.
-  uint32_t count;
-  uint32_t nCountedForRepair;
-  uint32_t nCorrupt;
-  uint32_t nRepaired;
-  uint32_t nBitDeletionErrors;
-  uint32_t nOneBitErrors;
-  uint32_t nTwoConsecutiveBitErrors;
-  uint32_t nTwoSeparateBitErrors;
-  uint32_t nUncertainBitErrors;
-  volatile int nQueued;
-  volatile int maxQueued;
-  
-  // Drop policy
-  int startDroppingPacketsAt;
-  bool (*isEssentialPacket)(const TVanPacketRxDesc&);
-  
-  void RegisterTxTimerTicks(uint32_t ticks) { txTimerTicks = ticks; };
-  void RegisterTxIsr(timercallback isr) { ISR_SAFE_SET(txTimerIsr, isr); };
-  
-  void SetLastMediaAccessAt(uint32_t at) { ISR_SAFE_SET(lastMediaAccessAt, at); };
-  
-  bool IsQueueOverrun() { NO_INTERRUPTS; bool result = _overrun; _overrun = false; INTERRUPTS; return result; }
-  
-  // Only to be called from ISR, unsafe otherwise
-  void _AdvanceHead();
-  
-  void AdvanceTail()
-  {
-    if (++tail == end) tail = pool;  // Roll over if needed
-    ISR_SAFE_SET(nQueued, nQueued - 1);
-  } // AdvanceTail
-  
-  static bool ActiveAckStatus;
-  static uint8_t idenAckLen;
-  static uint16_t idenAck[];
+    uint8_t pin;
+    bool enabled;
+    int size;
+    TVanPacketRxDesc* pool;
+    TVanPacketRxDesc* volatile _head;
+    TVanPacketRxDesc* tail;
+    TVanPacketRxDesc* end;
+    volatile bool _overrun;
+    uint32_t txTimerTicks;
+    timercallback txTimerIsr;
+    volatile uint32_t lastMediaAccessAt;  // For carrier sense: CPU cycle counter value when last sensed
+    
+    #ifdef VAN_RX_ISR_DEBUGGING
+    #define N_ISR_DEBUG_PACKETS 3
+    TIsrDebugPacket isrDebugPacketPool[N_ISR_DEBUG_PACKETS];
+    TIsrDebugPacket* isrDebugPacket;
+    #endif // VAN_RX_ISR_DEBUGGING
+    
+    // Some statistics. Numbers can roll over.
+    uint32_t count;
+    uint32_t nCountedForRepair;
+    uint32_t nCorrupt;
+    uint32_t nRepaired;
+    uint32_t nBitDeletionErrors;
+    uint32_t nOneBitErrors;
+    uint32_t nTwoConsecutiveBitErrors;
+    uint32_t nTwoSeparateBitErrors;
+    uint32_t nUncertainBitErrors;
+    volatile int nQueued;
+    volatile int maxQueued;
+    
+    // Drop policy
+    int startDroppingPacketsAt;
+    bool (*isEssentialPacket)(const TVanPacketRxDesc&);
+    
+    void RegisterTxTimerTicks(uint32_t ticks) { txTimerTicks = ticks; };
+    void RegisterTxIsr(timercallback isr) { ISR_SAFE_SET(txTimerIsr, isr); };
+    
+    void SetLastMediaAccessAt(uint32_t at) { ISR_SAFE_SET(lastMediaAccessAt, at); };
+    
+    bool IsQueueOverrun() { NO_INTERRUPTS; bool result = _overrun; _overrun = false; INTERRUPTS; return result; }
+    
+    // Only to be called from ISR, unsafe otherwise
+    void _AdvanceHead();
+    
+    void AdvanceTail()
+    {
+      if (++tail == end) tail = pool;  // Roll over if needed
+      ISR_SAFE_SET(nQueued, nQueued - 1);
+    } // AdvanceTail
+    
+    static bool ActiveAckStatus;
+    static uint8_t idenAckLen;
+    static uint16_t idenAck[];
 
-  friend void FinishPacketTransmission(TVanPacketTxDesc* txDesc);
-  friend void SendBitIsr();
-  friend void RxPinChangeIsr();
-  friend void SetTxBitTimer();
-  friend void WaitAckIsr();
-  friend class TVanPacketRxDesc;
-  friend class TVanPacketTxQueue;
+    friend void FinishPacketTransmission(TVanPacketTxDesc* txDesc);
+    friend void SendBitIsr();
+    friend void RxPinChangeIsr();
+    friend void SetTxBitTimer();
+    friend void WaitAckIsr();
+    friend class TVanPacketRxDesc;
+    friend class TVanPacketTxQueue;
 }; // class TVanPacketRxQueue
 
 extern TVanPacketRxQueue VanBusRx;

--- a/src/VanBusRx.h
+++ b/src/VanBusRx.h
@@ -421,13 +421,13 @@ class TVanPacketRxQueue
     uint32_t txTimerTicks;
     timercallback txTimerIsr;
     volatile uint32_t lastMediaAccessAt;  // For carrier sense: CPU cycle counter value when last sensed
-    
-    #ifdef VAN_RX_ISR_DEBUGGING
+
+  #ifdef VAN_RX_ISR_DEBUGGING
     #define N_ISR_DEBUG_PACKETS 3
     TIsrDebugPacket isrDebugPacketPool[N_ISR_DEBUG_PACKETS];
     TIsrDebugPacket* isrDebugPacket;
-    #endif // VAN_RX_ISR_DEBUGGING
-    
+  #endif // VAN_RX_ISR_DEBUGGING
+
     // Some statistics. Numbers can roll over.
     uint32_t count;
     uint32_t nCountedForRepair;
@@ -440,25 +440,25 @@ class TVanPacketRxQueue
     uint32_t nUncertainBitErrors;
     volatile int nQueued;
     volatile int maxQueued;
-    
+
     // Drop policy
     int startDroppingPacketsAt;
     bool (*isEssentialPacket)(const TVanPacketRxDesc&);
-    
+
     void RegisterTxTimerTicks(uint32_t ticks) { txTimerTicks = ticks; };
     void RegisterTxIsr(timercallback isr) { ISR_SAFE_SET(txTimerIsr, isr); };
-    
+
     void SetLastMediaAccessAt(uint32_t at) { ISR_SAFE_SET(lastMediaAccessAt, at); };
-    
+
     bool IsQueueOverrun() { NO_INTERRUPTS; bool result = _overrun; _overrun = false; INTERRUPTS; return result; }
-    
+
     // Only to be called from ISR, unsafe otherwise
     void _AdvanceHead();
-    
+
     void AdvanceTail()
     {
-      if (++tail == end) tail = pool;  // Roll over if needed
-      ISR_SAFE_SET(nQueued, nQueued - 1);
+        if (++tail == end) tail = pool;  // Roll over if needed
+        ISR_SAFE_SET(nQueued, nQueued - 1);
     } // AdvanceTail
     
     static bool ActiveAckStatus;

--- a/src/VanBusRx.h
+++ b/src/VanBusRx.h
@@ -73,6 +73,7 @@
 
 // Forward declarations
 
+extern uint8_t globalTxPin;
 void WaitAckIsr();
 void RxPinChangeIsr();
 
@@ -166,7 +167,7 @@ class TIfsDebugPacket
 
 enum PacketReadState_t { VAN_RX_VACANT = 2, VAN_RX_SEARCHING, VAN_RX_LOADING, VAN_RX_WAITING_ACK, VAN_RX_DONE };
 enum PacketReadResult_t { VAN_RX_PACKET_OK, VAN_RX_ERROR_NBITS, VAN_RX_ERROR_MANCHESTER, VAN_RX_ERROR_MAX_PACKET };
-enum PacketAck_t { VAN_ACK, VAN_NO_ACK };
+enum PacketAck_t { VAN_ACK, VAN_NO_ACK, VAN_ACTIVE_ACK };
 
 // VAN packet Rx descriptor
 class TVanPacketRxDesc
@@ -212,7 +213,7 @@ class TVanPacketRxDesc
         return result;
     } // CommandFlagsStr
 
-    const char* AckStr() const { return ack == VAN_ACK ? "ACK" : ack == VAN_NO_ACK ? "NO_ACK": "ACK_??"; }
+    const char* AckStr() const { return ack == VAN_ACK ? "ACK" : ack == VAN_NO_ACK ? "NO_ACK": ack == VAN_ACTIVE_ACK ? "ACTIVE_ACK" : "ACK_??"; }
 
     const char* ResultStr() const
     {
@@ -279,7 +280,7 @@ class TVanPacketRxDesc
         size = 0;
         state = VAN_RX_VACANT;
         result = VAN_RX_PACKET_OK;
-        ack = VAN_NO_ACK;
+        ack = VAN_NO_ACK;        
 
       #define NO_UNCERTAIN_BIT (0)
         uncertainBit1 = NO_UNCERTAIN_BIT;
@@ -301,6 +302,8 @@ class TVanPacketRxDesc
     } // ResultStr
 
     bool CheckCrcFix(bool mustCount, uint32_t* pCounter1, uint32_t* pCounter2 = nullptr);
+
+    bool decisionActiveACK();
 
     friend void WaitAckIsr();
     friend void RxPinChangeIsr();
@@ -382,8 +385,10 @@ class TVanPacketRxQueue
 
     bool Setup(uint8_t rxPin, int queueSize = VAN_DEFAULT_RX_QUEUE_SIZE);
     void SetTxPinRecessive(uint8_t txPin);
+    void SetTxPinDominant(uint8_t txPin);
     bool Available() const { ISR_SAFE_GET(bool, tail->state == VAN_RX_DONE); }
     bool Receive(TVanPacketRxDesc& pkt, bool* isQueueOverrun = NULL);
+    void ActiveACK(const uint8_t len, const uint16_t array[]);
 
     // Disabling the VAN bus receiver is necessary for timer-intensive tasks, like e.g. operations on the SPI Flash
     // File System (SPIFFS), which otherwise cause system crash. Unfortunately, after disabling then enabling the
@@ -405,64 +410,68 @@ class TVanPacketRxQueue
 
   private:
 
-    uint8_t pin;
-    bool enabled;
-    int size;
-    TVanPacketRxDesc* pool;
-    TVanPacketRxDesc* volatile _head;
-    TVanPacketRxDesc* tail;
-    TVanPacketRxDesc* end;
-    volatile bool _overrun;
-    uint32_t txTimerTicks;
-    timercallback txTimerIsr;
-    volatile uint32_t lastMediaAccessAt;  // For carrier sense: CPU cycle counter value when last sensed
-
+  uint8_t pin;
+  bool enabled;
+  int size;
+  TVanPacketRxDesc* pool;
+  TVanPacketRxDesc* volatile _head;
+  TVanPacketRxDesc* tail;
+  TVanPacketRxDesc* end;
+  volatile bool _overrun;
+  uint32_t txTimerTicks;
+  timercallback txTimerIsr;
+  volatile uint32_t lastMediaAccessAt;  // For carrier sense: CPU cycle counter value when last sensed
+  
   #ifdef VAN_RX_ISR_DEBUGGING
-    #define N_ISR_DEBUG_PACKETS 3
-    TIsrDebugPacket isrDebugPacketPool[N_ISR_DEBUG_PACKETS];
-    TIsrDebugPacket* isrDebugPacket;
+  #define N_ISR_DEBUG_PACKETS 3
+  TIsrDebugPacket isrDebugPacketPool[N_ISR_DEBUG_PACKETS];
+  TIsrDebugPacket* isrDebugPacket;
   #endif // VAN_RX_ISR_DEBUGGING
+  
+  // Some statistics. Numbers can roll over.
+  uint32_t count;
+  uint32_t nCountedForRepair;
+  uint32_t nCorrupt;
+  uint32_t nRepaired;
+  uint32_t nBitDeletionErrors;
+  uint32_t nOneBitErrors;
+  uint32_t nTwoConsecutiveBitErrors;
+  uint32_t nTwoSeparateBitErrors;
+  uint32_t nUncertainBitErrors;
+  volatile int nQueued;
+  volatile int maxQueued;
+  
+  // Drop policy
+  int startDroppingPacketsAt;
+  bool (*isEssentialPacket)(const TVanPacketRxDesc&);
+  
+  void RegisterTxTimerTicks(uint32_t ticks) { txTimerTicks = ticks; };
+  void RegisterTxIsr(timercallback isr) { ISR_SAFE_SET(txTimerIsr, isr); };
+  
+  void SetLastMediaAccessAt(uint32_t at) { ISR_SAFE_SET(lastMediaAccessAt, at); };
+  
+  bool IsQueueOverrun() { NO_INTERRUPTS; bool result = _overrun; _overrun = false; INTERRUPTS; return result; }
+  
+  // Only to be called from ISR, unsafe otherwise
+  void _AdvanceHead();
+  
+  void AdvanceTail()
+  {
+    if (++tail == end) tail = pool;  // Roll over if needed
+    ISR_SAFE_SET(nQueued, nQueued - 1);
+  } // AdvanceTail
+  
+  static bool ActiveAckStatus;
+  static uint8_t idenAckLen;
+  static uint16_t idenAck[];
 
-    // Some statistics. Numbers can roll over.
-    uint32_t count;
-    uint32_t nCountedForRepair;
-    uint32_t nCorrupt;
-    uint32_t nRepaired;
-    uint32_t nBitDeletionErrors;
-    uint32_t nOneBitErrors;
-    uint32_t nTwoConsecutiveBitErrors;
-    uint32_t nTwoSeparateBitErrors;
-    uint32_t nUncertainBitErrors;
-    volatile int nQueued;
-    volatile int maxQueued;
-
-    // Drop policy
-    int startDroppingPacketsAt;
-    bool (*isEssentialPacket)(const TVanPacketRxDesc&);
-
-    void RegisterTxTimerTicks(uint32_t ticks) { txTimerTicks = ticks; };
-    void RegisterTxIsr(timercallback isr) { ISR_SAFE_SET(txTimerIsr, isr); };
-
-    void SetLastMediaAccessAt(uint32_t at) { ISR_SAFE_SET(lastMediaAccessAt, at); };
-
-    bool IsQueueOverrun() { NO_INTERRUPTS; bool result = _overrun; _overrun = false; INTERRUPTS; return result; }
-
-    // Only to be called from ISR, unsafe otherwise
-    void _AdvanceHead();
-
-    void AdvanceTail()
-    {
-        if (++tail == end) tail = pool;  // Roll over if needed
-        ISR_SAFE_SET(nQueued, nQueued - 1);
-    } // AdvanceTail
-
-    friend void FinishPacketTransmission(TVanPacketTxDesc* txDesc);
-    friend void SendBitIsr();
-    friend void RxPinChangeIsr();
-    friend void SetTxBitTimer();
-    friend void WaitAckIsr();
-    friend class TVanPacketRxDesc;
-    friend class TVanPacketTxQueue;
+  friend void FinishPacketTransmission(TVanPacketTxDesc* txDesc);
+  friend void SendBitIsr();
+  friend void RxPinChangeIsr();
+  friend void SetTxBitTimer();
+  friend void WaitAckIsr();
+  friend class TVanPacketRxDesc;
+  friend class TVanPacketTxQueue;
 }; // class TVanPacketRxQueue
 
 extern TVanPacketRxQueue VanBusRx;

--- a/src/VanBusTx.cpp
+++ b/src/VanBusTx.cpp
@@ -32,6 +32,8 @@
 
 #endif // ARDUINO_ARCH_ESP32
 
+uint8_t globalTxPin = VAN_NO_PIN_ASSIGNED;
+
 // Finish packet transmission
 void IRAM_ATTR FinishPacketTransmission(TVanPacketTxDesc* txDesc)
 {
@@ -169,6 +171,7 @@ void IRAM_ATTR SendBitIsr()
 void TVanPacketTxQueue::Setup(uint8_t theRxPin, uint8_t theTxPin)
 {
     txPin = theTxPin;
+    globalTxPin = txPin;
 
     pinMode(theTxPin, OUTPUT);
     digitalWrite(theTxPin, VAN_BIT_RECESSIVE);  // Set bus state to 'recessive' (CANH and CANL: not driven)


### PR DESCRIPTION
This PR is the first milestone for supporting acknowledgment and RTR frames. I called this feature activeACK to distinguish from the acknowledgement detection already present in the library.
The issue #18 is about the development of this feature.

## The test results

There is a negligeable variation of the timing from frame to frame. My observations shows that the start of the ack can happen from 6.5us to 9us after EOD for a target of 7us, which I consider a good accuracy given no additional hardware timer is used. The end of the ack pulse is accurate within 1us, reproducing the behavior of an original equipment.
The function decisionActiveACK() can successful distinguish the frames with the correct addresses from the others, and do not triggers if it is a RTR frame or if the Request Acknowledge (RAK) bit is 0.
<img width="1186" height="75" alt="image" src="https://github.com/user-attachments/assets/911bbc6e-5adc-48ac-b9a0-28d5c6caa3fc" />

The raw sigrok/pulseview file is available (remove the .txt extension) :
[activeACK timing 02 on cdc off.dsl.txt](https://github.com/user-attachments/files/27432955/activeACK.timing.02.on.cdc.off.dsl.txt)
